### PR TITLE
Fix duplicated items issue

### DIFF
--- a/src/coffee/intersectarrays.coffee
+++ b/src/coffee/intersectarrays.coffee
@@ -7,9 +7,12 @@ intersectArrays = ->
   for item in arguments
     return [] unless isArray item
 
+    checkedValues = {}
     for key in item
-      values[key] ?= 0
-      values[key]++
+      if !checkedValues[key]
+        values[key] ?= 0
+        values[key]++
+        checkedValues[key] = true
 
   result = []
   for key, count of values

--- a/test/src/intersectarrays.spec.coffee
+++ b/test/src/intersectarrays.spec.coffee
@@ -23,3 +23,7 @@ describe 'intersectArrays', ->
   it 'should return unique values', ->
     result = intersectArrays ['a', 'b'], ['a', 'b', 'c'], ['a', 'b', 'a']
     expect(result.length).toEqual 2
+
+  it 'should work with duplicated values', ->
+    result = intersectArrays ['a', 'b', 'a'], ['b', 'c'], ['a', 'b']
+    expect(result).toEqual ['b']


### PR DESCRIPTION
There is an issue when one array contains duplicated items and another one don't contain that item, so the counting breaks.

Feel free to change it if it don't match tour style guide as coffee script is mystery for me :)
